### PR TITLE
Update organization references in documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install --no-cache-dir \
 WORKDIR /usr/src/app
 
 ARG OPENCADC_BRANCH=master
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
 ARG PIPE_REPO=opencadc
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/auth/request.html) In this direct
 1. Get the script that executes the pipeline by doing the following:
 
    ```
-   wget https://raw.github.com/opencadc/phangs2caom2/master/scripts/phangs_run.sh
+   wget https://raw.github.com/opencadc-metadata-curation/phangs2caom2/master/scripts/phangs_run.sh
    ```
 
 1. Ensure the script is executable:

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/auth/request.html) In this direct
    root@53bef30d8af3:/usr/src/app# phangs_run
    ```
 
-1. For a description of the `config.yml` file, see: https://github.com/opencadc/collection2caom2/wiki/config.yml
+1. For a description of the `config.yml` file, see: https://github.com/opencadc-metadata-curation/collection2caom2/wiki/config.yml
 
 1. For some instructions that might be helpful on using containers, see:
-https://github.com/opencadc/collection2caom2/wiki/Docker-and-Collections
+https://github.com/opencadc-metadata-curation/collection2caom2/wiki/Docker-and-Collections
 
-1. For some insight into what's happening, see: https://github.com/opencadc/collection2caom2
+1. For some insight into what's happening, see: https://github.com/opencadc-metadata-curation/collection2caom2

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/phangs2caom2
+github_project = opencadc-metadata-curation/phangs2caom2
 install_requires = caom2utils caom2repo cadcdata
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.0


### PR DESCRIPTION
Update GitHub URLs in documentation from `opencadc` to `opencadc-metadata-curation` following repository transfer.

**Note:** Docker image references are not changed in this PR.