### PR TITLE
Update Dockerfile ARG variables for organization migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /usr/src/app
 ARG OPENCADC_BRANCH=master
 ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
-ARG PIPE_REPO=opencadc
+ARG PIPE_REPO=opencadc-metadata-curation
 
 RUN pip install git+https://github.com/${OPENCADC_REPO}/caom2pipe.git@${OPENCADC_BRANCH}#egg=caom2pipe
 


### PR DESCRIPTION
## Summary
Update Dockerfile ARG variables to reflect the repository transfer from opencadc to opencadc-metadata-curation organization.

## Changes
- Update PIPE_REPO from opencadc to opencadc-metadata-curation

This ensures pip install commands correctly reference the new repository location:
```
pip install git+https://github.com/opencadc-metadata-curation/phangs2caom2
```

Note: Docker base image references (FROM opencadc/...) remain unchanged as those are still hosted under the opencadc organization.